### PR TITLE
Add serialization-based save system with validation and locking

### DIFF
--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/App.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/App.java
@@ -18,8 +18,8 @@ public class App {
             JPanel mainPanel = new JPanel(cardLayout);
 
             // Create all game views
-            MainMenuPanel menu = new MainMenuPanel(cardLayout, mainPanel);
             GamePanel game = new GamePanel(cardLayout, mainPanel); // --- UPDATED: Pass layout to GamePanel ---
+            MainMenuPanel menu = new MainMenuPanel(cardLayout, mainPanel, game);
             ShopPanel shop = new ShopPanel(cardLayout, mainPanel);   // --- NEW: Create ShopPanel ---
 
             // Add all panels to the layout

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/GameState.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/GameState.java
@@ -1,13 +1,15 @@
 package com.yourname.blueprinthell.model;
 
 import java.awt.Point;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class GameState {
+public class GameState implements Serializable {
+    private static final long serialVersionUID = 1L;
     public enum GameStatus { RUNNING, PAUSED, GAME_OVER, WIN }
     private GameStatus currentStatus = GameStatus.RUNNING;
 

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/Packet.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/Packet.java
@@ -1,8 +1,10 @@
 package com.yourname.blueprinthell.model;
 
 import java.awt.*;
+import java.io.Serializable;
 
-public class Packet {
+public class Packet implements Serializable {
+    private static final long serialVersionUID = 1L;
     public enum Shape { SQUARE, TRIANGLE }
 
     private Shape shape;

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/SystemNode.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/SystemNode.java
@@ -1,12 +1,14 @@
 package com.yourname.blueprinthell.model;
 
 import java.awt.*;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
-public class SystemNode {
+public class SystemNode implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Point location;
     private Queue<Packet> buffer;
     private int bufferCapacity = 5;

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/Wire.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/model/Wire.java
@@ -1,8 +1,10 @@
 package com.yourname.blueprinthell.model;
 
 import java.awt.*;
+import java.io.Serializable;
 
-public class Wire {
+public class Wire implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Point start;
     private Point end;
     private Packet occupyingPacket; // null if wire is free

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/util/SaveManager.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/util/SaveManager.java
@@ -1,0 +1,95 @@
+package com.yourname.blueprinthell.util;
+
+import com.yourname.blueprinthell.model.GameState;
+
+import java.io.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Utility class responsible for saving and loading the {@link GameState}.
+ * The game state is serialized and a SHA-256 checksum is stored alongside
+ * the data to validate integrity during load operations. Concurrent save
+ * and load requests are synchronized using a read/write lock.
+ */
+public class SaveManager {
+
+    private static final ReentrantReadWriteLock LOCK = new ReentrantReadWriteLock();
+
+    private SaveManager() {
+        // Utility class
+    }
+
+    /**
+     * Saves the provided game state to the given file. The operation is
+     * protected by the write lock to prevent concurrent modifications while
+     * a save is in progress.
+     */
+    public static void save(GameState state, String file) throws IOException {
+        LOCK.writeLock().lock();
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(state);
+            oos.flush();
+            byte[] data = baos.toByteArray();
+
+            byte[] checksum = checksum(data);
+            ObjectOutputStream fileOut = new ObjectOutputStream(new FileOutputStream(file));
+            fileOut.writeObject(new SaveData(data, checksum));
+            fileOut.close();
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Loads a game state from the specified file. The read lock allows
+     * multiple concurrent load operations while preventing saves.
+     */
+    public static GameState load(String file) throws IOException, ClassNotFoundException {
+        LOCK.readLock().lock();
+        try {
+            ObjectInputStream fileIn = new ObjectInputStream(new FileInputStream(file));
+            SaveData data = (SaveData) fileIn.readObject();
+            fileIn.close();
+
+            byte[] expected = checksum(data.stateBytes);
+            if (!Arrays.equals(expected, data.checksum)) {
+                throw new IOException("Save data corrupted");
+            }
+
+            ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data.stateBytes));
+            return (GameState) ois.readObject();
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+
+    private static byte[] checksum(byte[] data) throws IOException {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return md.digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException("Unable to compute checksum", e);
+        }
+    }
+
+    /**
+     * Simple wrapper class used for storing the serialized game state and
+     * its checksum. This class is kept private to avoid leaking the
+     * internal representation.
+     */
+    private static class SaveData implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final byte[] stateBytes;
+        private final byte[] checksum;
+
+        SaveData(byte[] stateBytes, byte[] checksum) {
+            this.stateBytes = stateBytes;
+            this.checksum = checksum;
+        }
+    }
+}

--- a/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/view/GamePanel.java
+++ b/Blueprint-Hell-main/Blueprint-Hell-phase-1/app/src/main/java/com/yourname/blueprinthell/view/GamePanel.java
@@ -2,9 +2,11 @@ package com.yourname.blueprinthell.view;
 
 import com.yourname.blueprinthell.controller.GameController; // NEW Import
 import com.yourname.blueprinthell.model.*;
+import com.yourname.blueprinthell.util.SaveManager;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
+import java.io.IOException;
 
 public class GamePanel extends JPanel implements ActionListener {
     private GameState gameState;
@@ -32,12 +34,36 @@ public class GamePanel extends JPanel implements ActionListener {
         resetGame(); // Initialize game state and controller
 
         setupUIButtons();
-        
+
         addFocusListener(new FocusAdapter() {
             @Override
             public void focusGained(FocusEvent e) {
                 if (gameState.getCurrentStatus() != GameState.GameStatus.GAME_OVER && gameState.getCurrentStatus() != GameState.GameStatus.WIN) {
                     timer.start();
+                }
+            }
+        });
+
+        // Key bindings for saving and loading the game
+        addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_S) {
+                    try {
+                        SaveManager.save(gameState, "save.dat");
+                    } catch (IOException ex) {
+                        ex.printStackTrace();
+                    }
+                } else if (e.getKeyCode() == KeyEvent.VK_L) {
+                    try {
+                        GameState loaded = SaveManager.load("save.dat");
+                        if (loaded != null) {
+                            gameState = loaded;
+                            gameController = new GameController(gameState, GamePanel.this, timer);
+                        }
+                    } catch (IOException | ClassNotFoundException ex) {
+                        ex.printStackTrace();
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary
- add thread-safe `SaveManager` that serializes `GameState` with SHA-256 checksum
- support save/load hotkeys in `GamePanel`
- make model classes serializable and update `App` wiring for new menu constructor

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_689f41d17a8883278df8ee15e78edb23